### PR TITLE
Added ssh restriction options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v0.1.2 (2016-02-14)
+-------------------
+- Changed chef_server_basename to basename
+- Changed chef_server_count to count
+- Added variable `ssh_cidrs` to allow SSH access restrictions. Default: `0.0.0.0/0`
+- Added ports 10000-10003 to security groups (push-jobs)
+- Supporting documentation updates
+
 v0.1.1 (2016-02-11)
 -------------------
 - Bump version

--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ These resources will incur charges on your AWS bill. It is your responsibility t
 * `aws_flavor`: The AWS instance type. Default: `c3.xlarge`
 * `aws_instance_name`: The AWS tag for Name. Default: `chef-server` will result in a Name tag of `${var.aws_instance_name}-${var.aws_instance_count}-${var.chef_org}`
 * `aws_instance_count`: The number of AWS instances to deploy. Deafult: `1`, DO NOT CHANGE!
+* `basename`: The CHEF server's basename. Default: `chef-server`
+* `count`: The CHEF Server count. Default: `1`; DO NOT CHANGE!
 * `org_short`: The organization to create on the CHEF Server. Default: `example`
 * `org_long`: The long organization name to create on the CHEF Server. Default: `Example CHEF Organization`
 * `username`: The first user for your chef server. Default: `example`
 * `user_firstname`: The first user's first name. Default: `Example`
 * `user_lastname`: The first user's last name. Default: `User`
 * `user_email`: The first user's e-mail address. Default: `example@domain.tld`
+* `ssh_cidrs`: The comma seperated list of addresses in CIDR format to allow SSH access. Default: `0.0.0.0/0`
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "aws_security_group_rule" "chef-server_allow_22_tcp_all" {
   from_port = 22
   to_port = 22
   protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks = ["${split(",", var.ssh_cidrs)}"]
   security_group_id = "${aws_security_group.chef-server.id}"
 }
 # HTTP (nginx)
@@ -44,7 +44,7 @@ resource "aws_security_group_rule" "chef-server_allow_9683_tcp_all" {
   security_group_id = "${aws_security_group.chef-server.id}"
 }
 # opscode-push-jobs
-resource "aws_security_group_rule" "chef-server_allow_9683_tcp_all" {
+resource "aws_security_group_rule" "chef-server_allow_10000-10003_tcp_all" {
   type = "ingress"
   from_port = 10000
   to_port = 10003
@@ -81,13 +81,13 @@ EOF
 # Provision CHEF Server
 resource "aws_instance" "chef-server" {
   ami = "${var.aws_ami_id}"
-  count = "${var.chef_server_count}"
+  count = "${var.count}"
   instance_type = "${var.aws_flavor}"
   subnet_id = "${var.aws_subnet_id}"
   vpc_security_group_ids = ["${aws_security_group.chef-server.id}"]
   key_name = "${var.aws_key_name}"
   tags = {
-    Name = "${format("%s-%02d-%s", var.chef_server_basename, count.index + 1, var.org_short)}"
+    Name = "${format("%s-%02d-%s", var.basename, count.index + 1, var.org_short)}"
   }
   root_block_device = {
     delete_on_termination = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,14 +2,17 @@
 output "id" {
   value = "${aws_instance.chef-server.id}"
 }
+output "security_group_id" {
+  value = "${aws_security_group.chef-server.id}"
+}
 output "public_ip" {
   value = "${aws_instance.chef-server.public_ip}"
 }
 output "public_dns" {
   value = "${aws_instance.chef-server.public_dns}"
 }
-output "security_group_id" {
-  value = "${aws_security_group.chef-server.id}"
+output "organization" {
+  value = "${var.org_short}"
 }
 output "chef_server_url" {
   value = "https://${aws_instance.chef-server.public_dns}/organizations/${var.org_short}"
@@ -22,9 +25,6 @@ output "password" {
 }
 output "username_pem" {
   value = "${path.cwd}/.chef/keys/${var.username}.pem"
-}
-output "organization" {
-  value = "${var.org_short}"
 }
 output "org_validator" {
   value = "${path.cwd}/.chef/keys/${var.org_short}-validator.pem"

--- a/variables.tf
+++ b/variables.tf
@@ -33,11 +33,11 @@ variable "aws_region" {
   default = "us-west-1"
 }
 # tf_chef_server specific configs
-variable "chef_server_count" {
+variable "count" {
   description = "Number of CHEF Servers to provision. DO NOT CHANGE!"
   default = 1
 }
-variable "chef_server_basename" {
+variable "basename" {
   description = "Basename for AWS Name tag of CHEF Server"
   default = "chef-server"
 }
@@ -64,4 +64,8 @@ variable "user_lastname" {
 variable "user_email" {
   description = "CHEF Server user's e-mail"
   default = "example@domain.tld"
+}
+variable "ssh_cidrs" {
+  description = "List of CIDRs to allow SSH from"
+  default = "0.0.0.0/0"
 }


### PR DESCRIPTION
- Changed chef_server_basename to basename
- Changed chef_server_count to count
- Added variable `ssh_cidrs` to allow SSH access restrictions. Default: `0.0.0.0/0`
- Added ports 10000-10003 to security groups (push-jobs)
- Supporting documentation updates