### PR TITLE
Added variable and run_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.2.5 (2016-03-22)
+-------------------
+- Added handle for internal DNS on Route53
+- Added recipe[system::default] to run_list
+
 v0.2.4 (2016-03-21)
 -------------------
 - Add runtime sample GIST

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ These resources will incur charges on your AWS bill. It is your responsibility t
 * `r53`: Boolean determines if Route53 will be used or not. Default: `0`
 * `r53_ttl`: Time to Live (TTL) setting for Route53 A record to be created. Default: `180`
 * `r53_zone_id`: AWS Route53 Zone ID to add an A record for the Chef Server
+* `r53_zone_internal_id`: AWS Route53 Internal Zone ID to add an A record for the Chef Server
 * `server_count`: Chef Server count. Default: `1`; DO NOT CHANGE!
 * `ssl_cert`: Chef Server SSL certificate in PEM format
 * `ssl_key`: Chef Server SSL certificate key

--- a/main.tf
+++ b/main.tf
@@ -166,7 +166,7 @@ EOC
   # Run chef-solo and get us a Chef server
   provisioner "remote-exec" {
     inline = [
-      "sudo chef-solo -j .chef/dna.json -o 'recipe[chef-server::default],recipe[chef-server::addons]'",
+      "sudo chef-solo -j .chef/dna.json -o 'recipe[system::default],recipe[chef-server::default],recipe[chef-server::addons]'",
     ]
   }
   # Create first user and org
@@ -244,6 +244,15 @@ resource "aws_route53_record" "chef-server" {
   type     = "A"
   ttl      = "${var.r53_ttl}"
   records  = ["${aws_instance.chef-server.public_ip}"]
+}
+# Private Route53 DNS record
+resource "aws_route53_record" "chef-server-private" {
+  count    = "${var.r53}"
+  zone_id  = "${var.r53_zone_internal_id}"
+  name     = "${aws_instance.chef-server.tags.Name}"
+  type     = "A"
+  ttl      = "${var.r53_ttl}"
+  records  = ["${aws_instance.chef-server.private_ip}"]
 }
 # Generate pretty output format
 resource "template_file" "chef-server-creds" {

--- a/variables.tf
+++ b/variables.tf
@@ -130,8 +130,12 @@ variable "r53_ttl" {
   description = "Route53 A record TTL (Default: 180)"
   default     = 180
 }
+variable "r53_zone_internal_id" {
+  description = "Route53 zone id for internal DNS"
+  default     = 0
+}
 variable "r53_zone_id" {
-  description = "Route53 Zone ID"
+  description = "Route53 zone id"
   default     = 0
 }
 variable "server_count" {


### PR DESCRIPTION
- `r53_zone_internal_id` added to handle split-zone route53 dns
- added system::default to run_list