### PR TITLE
Syntax updates per TF 0.6.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.2.6 (2016-03-28)
+-------------------
+- Syntax update per Terraform [0.6.14](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#0614-march-21-2016)
+
 v0.2.5 (2016-03-22)
 -------------------
 - Added handle for internal DNS on Route53

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Terraform module to setup a Chef Server in standalone mode. Nothing spectacular 
   * AWS subnet id
   * AWS VPC id
   * SSL certificate/key for created instance
+  * Terraform >= 0.6.14
 * Uses a public IP and public DNS
 * Creates default security group as follows:
   * 22/tcp: SSH

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ EOF
 }
 # Chef provisiong attributes_json and .chef/dna.json templating
 resource "template_file" "attributes-json" {
-  template = "${path.module}/files/attributes-json.tpl"
+  template = "${file("${path.module}/files/attributes-json.tpl")}"
   vars {
     host   = "${var.hostname}"
     domain = "${var.domain}"
@@ -89,7 +89,7 @@ resource "template_file" "attributes-json" {
 }
 # knife.rb templating
 resource "template_file" "knife-rb" {
-  template = "${path.module}/files/knife-rb.tpl"
+  template = "${file("${path.module}/files/knife-rb.tpl")}"
   vars {
     user   = "${var.username}"
     fqdn   = "${var.hostname}.${var.domain}"
@@ -256,7 +256,7 @@ resource "aws_route53_record" "chef-server-private" {
 }
 # Generate pretty output format
 resource "template_file" "chef-server-creds" {
-  template = "${path.module}/files/chef-server-creds.tpl"
+  template = "${file("${path.module}/files/chef-server-creds.tpl")}"
   vars {
     user   = "${var.username}"
     pass   = "${base64sha256(aws_instance.chef-server.id)}"


### PR DESCRIPTION
- template_file resources now use `"${file("")}` instead of a raw path
- Doc updates supporting TF version update requirements