### PR TITLE
Release v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ tf_chef_server CHANGELOG
 
 This file is used to list changes made in each version of the tf_chef_server Terraform plan.
 
+v1.0.5 (2016-04-28)
+-------------------
+- [Brian Menges] - Require users of plan to specify `accept_license` and set to `1` to indicate agreement with [Chef MLSA](https://www.chef.io/online-master-agreement/)
+- [Brian Menges] - Implement `null_resource.chef_mlsa` between prep and chef-solo run
+- [Brian Menges] - Update a few `depends_on` blocks
+- [Brian Menges] - Fix an scp copy back for files
+
 v1.0.4 (2016-04-26)
 -------------------
 - [Brian Menges] - Fix [chef-server-creds](files/chef-server-creds.tpl) template. Specify User PEM and Org Validator files correctly

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ These resources will incur charges on your AWS bill. It is your responsibility t
 
 ### tf_chef_server variables
 
+* `accept_license`: [Chef MLSA license](https://www.chef.io/online-master-agreement/) acceptance indicator. Default: `0`; change to `1` to indicate agreement
 * `allowed_cidrs`: The comma seperated list of addresses in CIDR format to allow SSH access. Default: `0.0.0.0/0`
 * `client_version`: Chef client version. Default: `12.8.1`
 * `domain`: Server's basename. Default: `localhost`

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,10 @@ variable "ami_usermap" {
 #
 # specific configs
 #
+variable "accept_license" {
+  description = "Acceptance of the Chef MLSA: https://www.chef.io/online-master-agreement/"
+  default     = 0
+}
 variable "allowed_cidrs" {
   description = "List of CIDRs to allow SSH from (CSV list allowed)"
   default     = "0.0.0.0/0"


### PR DESCRIPTION
- [Brian Menges] - Require users of plan to specify `accept_license` and set to `1` to indicate agreement with [Chef MLSA](https://www.chef.io/online-master-agreement/)
- [Brian Menges] - Implement `null_resource.chef_mlsa` between prep and chef-solo run
- [Brian Menges] - Update a few `depends_on` blocks
- [Brian Menges] - Fix an scp copy back for files