### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ tf_chef_server CHANGELOG
 
 This file is used to list changes made in each version of the tf_chef_server Terraform plan.
 
+v1.1.0 (2016-05-02)
+-------------------
+- [Brian Menges] - Replaced `accept_license` numeric with boolean. Now part of `template_file.attributes-json`
+- [Brian Menges] - Added `volume_size` and `volume_type` specifications and `root_` variables for mentioned tunables to instance deployted
+- [Brian Menges] - Removed `null_resource` for Chef MLSA handles
+- [Brian Menges] - Added `server_version` to specify Chef Server installation version
+- [Brian Menges] - Set default `root_volume_size` to 20 GB
+- [Brian Menges] - Set default `root_volume_type` to `standard`
+- [Brian Menges] - Added Name tag to `root_block_device` of `${var.hostname}.${var.domain} /`
+- [Brian Menges] - NOTE: incompatible with root type `io1`
+
 v1.0.6 (2016-04-28)
 -------------------
 - [Brian Menges] - Attempt simplier method to `accept_license`

--- a/files/attributes-json.tpl
+++ b/files/attributes-json.tpl
@@ -4,6 +4,7 @@
      "init_style": "none"
    },
   "chef-server": {
+    "accept_license": ${license},
     "addons": [
       "manage",
       "push-jobs-server",
@@ -11,7 +12,8 @@
     ],
     "api_fqdn": "${host}.${domain}",
     "configuration": "nginx['ssl_certificate'] = '/var/chef/ssl/${host}.${domain}.pem'\nnginx['ssl_certificate_key'] = '/var/chef/ssl/${host}.${domain}.key'",
-    "topology": "standalone"
+    "topology": "standalone",
+    "version": "${version}"
   },
   "firewall": {
     "allow_established": true,

--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "ami_usermap" {
 #
 variable "accept_license" {
   description = "Acceptance of the Chef MLSA: https://www.chef.io/online-master-agreement/"
-  default     = 0
+  default     = false
 }
 variable "allowed_cidrs" {
   description = "List of CIDRs to allow SSH from (CSV list allowed)"
@@ -142,9 +142,21 @@ variable "root_delete_termination" {
   description = "Delete server root block device on termination"
   default     = true
 }
+variable "root_volume_size" {
+  description = "Size in GB of root device"
+  default     = 20
+}
+variable "root_volume_type" {
+  description = "Type of root volume"
+  default     = "standard"
+}
 variable "server_count" {
   description = "Number of Chef Servers to provision. DO NOT CHANGE!"
   default     = 1
+}
+variable "server_version" {
+  description = "Chef Server version"
+  default     = "12.6.0"
 }
 variable "ssl_cert" {
   description = "SSL Certificate in PEM format"


### PR DESCRIPTION
- [Brian Menges] - Replaced `accept_license` numeric with boolean. Now part of `template_file.attributes-json`
- [Brian Menges] - Added `volume_size` and `volume_type` specifications and `root_` variables for mentioned tunables to instance deployted
- [Brian Menges] - Removed `null_resource` for Chef MLSA handles
- [Brian Menges] - Added `server_version` to specify Chef Server installation version
- [Brian Menges] - Set default `root_volume_size` to 20 GB
- [Brian Menges] - Set default `root_volume_type` to `standard`
- [Brian Menges] - Added Name tag to `root_block_device` of `${var.hostname}.${var.domain} /`
- [Brian Menges] - NOTE: incompatible with root type `io1`